### PR TITLE
better error message if kid is not found

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 requests
+        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 requests types-requests
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 requests
+        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 requests types-requests
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -137,7 +137,7 @@ class Auth0:
                 )
             else:
                 if self.auto_error:
-                    raise jwt.JWTError
+                    raise Auth0UnauthorizedException(detail='Invalid kid header (no matching public key)')
 
         except jwt.ExpiredSignatureError:
             if self.auto_error:

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -137,7 +137,7 @@ class Auth0:
                 )
             else:
                 if self.auto_error:
-                    raise Auth0UnauthorizedException(detail='Invalid kid header (no matching public key)')
+                    raise Auth0UnauthenticatedException(detail='Invalid kid header (no matching public key)')
 
         except jwt.ExpiredSignatureError:
             if self.auto_error:
@@ -156,6 +156,9 @@ class Auth0:
                 raise Auth0UnauthenticatedException(detail='Malformed token')
             else:
                 return None
+
+        except Auth0UnauthenticatedException:
+            raise
 
         except Exception as e:
             logging.error(f'Handled exception decoding token: "{e}"')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -265,3 +265,20 @@ def test_token():
     assert resp.status_code == 401, resp.text
     error_detail = resp.json()['detail']
     assert 'malformed' in error_detail.lower(), error_detail
+
+    token_for_another_tennant = (
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InFIRkgxZmVLclg1TENaVXRTN2ZOVCJ9."
+        "eyJpc3MiOiJodHRwczovL2Rldi05enlpOWM5bS51cy5hdXRoMC5jb20vIiwic3ViIjoiZXJsWWZLQ"
+        "U1XemZBQmxUcjR6QjAzYnpiN3dkeHVobzBAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vcXVpY2tzdG"
+        "FydHMvYXBpIiwiaWF0IjoxNjM5MTMwMzkzLCJleHAiOjE2MzkyMTY3OTMsImF6cCI6ImVybFlmS0F"
+        "NV3pmQUJsVHI0ekIwM2J6Yjd3ZHh1aG8wIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.vv8Z"
+        "S1yLl5yTczjwCwW-6-vA3gjXSu5WZvTM4mcJGzfhplW_uzlJEncnDEc6-FO4yVoGxQ_6sSo_GfABk"
+        "hIP-L9iWd127KptML-PHWzeJAcI12yaCE6592CK_tK_tNhxRRMBGSv3cZaj0eXSlkQXFNMvS5J575"
+        "6gW6HYTe9FqBLMM2kJRW6T9GcehpBiymqLbDVNTffXhNGJHKBGA3VNAgSQp4rzzF7wljyxa9IJqot"
+        "owHKQxezwEpUBVDiurytRkHSZx9ShiWJKmd6ikxh6YJAjzJZkdxKgQQP6tgTB8m0P0O-CDt2j_w4Q"
+        "VtUrQe8tz2qQSzhJYEBOBGTwKf_Okw"
+    )
+    resp = client.get('/secure', headers=get_bearer_header(token_for_another_tennant))
+    assert resp.status_code == 401, resp.text
+    error_detail = resp.json()['detail']
+    assert 'invalid kid header (no matching public key)' in error_detail.lower(), error_detail


### PR DESCRIPTION
Closes #19 

I've used a similar error message to what they use here: https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication