### PR TITLE
Add UnauthorizedException when kid is not provided

### DIFF
--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -132,6 +132,13 @@ class Auth0:
             unverified_header = jwt.get_unverified_header(token)
             rsa_key = {}
             for key in self.jwks['keys']:
+                if "kid" not in unverified_header:
+                    msg = 'kid header not provided.'
+                    if self.auto_error:
+                        raise Auth0UnauthorizedException(detail=msg)
+                    else:
+                        logger.warning(msg)
+                        return None
                 if key['kid'] == unverified_header['kid']:
                     rsa_key = {
                         'kty': key['kty'],

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -133,7 +133,7 @@ class Auth0:
             rsa_key = {}
             for key in self.jwks['keys']:
                 if "kid" not in unverified_header:
-                    msg = 'kid header not provided.'
+                    msg = 'Malformed token'
                     if self.auto_error:
                         raise Auth0UnauthenticatedException(detail=msg)
                     else:

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -135,7 +135,7 @@ class Auth0:
                 if "kid" not in unverified_header:
                     msg = 'kid header not provided.'
                     if self.auto_error:
-                        raise Auth0UnauthorizedException(detail=msg)
+                        raise Auth0UnauthenticatedException(detail=msg)
                     else:
                         logger.warning(msg)
                         return None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -297,4 +297,4 @@ def test_token():
     resp = client.get('/secure', headers=get_bearer_header(invalid_token))
     assert resp.status_code == 401, resp.text
     error_detail = resp.json()['detail']
-    assert 'kid header not provided.' in error_detail.lower(), error_detail
+    assert 'malformed' in error_detail.lower(), error_detail


### PR DESCRIPTION
Hello,

We noticed the following problem in our setup recently:
We have a bot calling our API without providing the `kid` in the header. Unfortunately, this crashes the endpoint, because it expects that `kid` is in `unverified_header`. I sketched a fix below BUT I don't know if this is sufficient.
Also, I don't know how to build a test case for this right now. Might figure it out but don't have the time currently.

Please let me know how I can get this across the finish line.

