### PR TITLE
Feature: Migrate to PyJWT from python-jose

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 pydantic-settings httpx requests types-requests
+        python -m pip install flake8 mypy pytest fastapi>=0.60.0 PyJWT>=2.8.0 pydantic-settings httpx requests types-requests
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 mypy pytest fastapi>=0.60.0 python-jose>=3.2.0 pydantic-settings httpx requests types-requests
+        python -m pip install flake8 mypy pytest fastapi>=0.60.0 PyJWT>=2.8.0 pydantic-settings httpx requests types-requests
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setuptools.setup(
     package_dir={'': 'src'},
     package_data={'': ['py.typed']},
     python_requires='>=3.7',
-    install_requires=['fastapi>=0.60.0', 'python-jose>=3.2.0']
+    install_requires=['fastapi>=0.60.0', 'PyJWT>=2.8.0']
 )

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -11,7 +11,6 @@ from fastapi.security import SecurityScopes, HTTPBearer, HTTPAuthorizationCreden
 from fastapi.security import OAuth2, OAuth2PasswordBearer, OAuth2AuthorizationCodeBearer, OpenIdConnect
 from fastapi.openapi.models import OAuthFlows, OAuthFlowImplicit
 from pydantic import BaseModel, Field, ValidationError
-from typing_extensions import TypedDict
 
 
 logger = logging.getLogger('fastapi_auth0')
@@ -60,18 +59,6 @@ class OAuth2ImplicitBearer(OAuth2):
         # Overwrite parent call to prevent useless overhead, the actual auth is done in Auth0.get_user
         # This scheme is just for Swagger UI
         return None
-
-
-class JwksKeyDict(TypedDict):
-    kid: str
-    kty: str
-    use: str
-    n: str
-    e: str
-
-class JwksDict(TypedDict):
-    keys: List[JwksKeyDict]
-
 
 
 class Auth0:

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -5,7 +5,6 @@ import urllib.parse
 import urllib.request
 
 import jwt
-from jwt import PyJWKClient
 from fastapi import HTTPException, Depends, Request
 from fastapi.security import SecurityScopes, HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.security import OAuth2, OAuth2PasswordBearer, OAuth2AuthorizationCodeBearer, OpenIdConnect
@@ -89,7 +88,7 @@ class Auth0:
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
         self.options = options
-        self.jwks_client = PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
+        self.jwks_client = jwt.PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 
 
     async def get_user(self,

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -87,7 +87,8 @@ class Auth0:
             tokenUrl=f'https://{domain}/oauth/token',
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
-        self.options = options or {"require": ["exp", "iat", "sub"]}
+        self.options = options or {}
+        self.options.update({"require": ["exp", "iat", "sub"]})
         self.jwks_client = jwt.PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 
 

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -14,6 +14,8 @@ from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger('fastapi_auth0')
 
+auth0_rule_namespace: str = os.getenv('AUTH0_RULE_NAMESPACE', 'https://github.com/dorinclisu/fastapi-auth0')
+
 
 class Auth0UnauthenticatedException(HTTPException):
     def __init__(self, detail: str, **kwargs):
@@ -36,7 +38,7 @@ security_responses:       Dict = {**unauthenticated_response, **unauthorized_res
 class Auth0User(BaseModel):
     id:                          str = Field(..., alias='sub')
     permissions: Optional[List[str]] = None
-    email:             Optional[str] = None
+    email:             Optional[str] = Field(None, alias=f'{auth0_rule_namespace}/email')  # type: ignore [literal-required]
 
 
 class Auth0HTTPBearer(HTTPBearer):

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -87,7 +87,7 @@ class Auth0:
             tokenUrl=f'https://{domain}/oauth/token',
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
-        self.options = options or {}
+        self.options = options or dict()
         self.options.update({"require": ["exp", "iat", "sub"]})
         self.jwks_client = jwt.PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -14,8 +14,6 @@ from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger('fastapi_auth0')
 
-auth0_rule_namespace: str = os.getenv('AUTH0_RULE_NAMESPACE', 'https://github.com/dorinclisu/fastapi-auth0')
-
 
 class Auth0UnauthenticatedException(HTTPException):
     def __init__(self, detail: str, **kwargs):
@@ -38,7 +36,7 @@ security_responses:       Dict = {**unauthenticated_response, **unauthorized_res
 class Auth0User(BaseModel):
     id:                          str = Field(..., alias='sub')
     permissions: Optional[List[str]] = None
-    email:             Optional[str] = Field(None, alias=f'{auth0_rule_namespace}/email')  # type: ignore [literal-required]
+    email:             Optional[str] = None
 
 
 class Auth0HTTPBearer(HTTPBearer):

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -87,7 +87,7 @@ class Auth0:
             tokenUrl=f'https://{domain}/oauth/token',
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
-        self.options = options
+        self.options = options or {"require": ["exp", "iat", "sub"]}
         self.jwks_client = jwt.PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 
 
@@ -127,7 +127,7 @@ class Auth0:
 
             try:
                 signing_key = self.jwks_client.get_signing_key_from_jwt(token)
-                leeway = self.options.pop("leeway", 0) if self.options else 0
+                leeway = self.options.pop("leeway", 0)
                 payload = jwt.decode(
                     token,
                     signing_key.key,

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -88,6 +88,12 @@ class Auth0:
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
         self.options = options or dict()
+        self.options.setdefault("verify_signature", True)
+        self.options.setdefault("verify_aud", True)
+        self.options.setdefault("verify_iss", True)
+        self.options.setdefault("verify_exp", True)
+        self.options.setdefault("verify_iat", True)
+        self.options.setdefault("require", ["iss", "sub", "aud", "iat", "exp"])
         self.jwks_client = jwt.PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 
 
@@ -129,7 +135,6 @@ class Auth0:
                 signing_key = self.jwks_client.get_signing_key_from_jwt(token)
                 options = self.options.copy()
                 leeway = options.pop("leeway", 0)
-                options.setdefault("require", ["iss", "sub", "aud", "iat", "exp"])
                 payload = jwt.decode(
                     token,
                     signing_key.key,

--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -1,11 +1,11 @@
-import json
 import logging
 import os
-from typing import Optional, Dict, List, Type
+from typing import Optional, Dict, List, Type, Any
 import urllib.parse
 import urllib.request
 
-from jose import jwt  # type: ignore
+import jwt
+from jwt import PyJWKClient
 from fastapi import HTTPException, Depends, Request
 from fastapi.security import SecurityScopes, HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.security import OAuth2, OAuth2PasswordBearer, OAuth2AuthorizationCodeBearer, OpenIdConnect
@@ -77,7 +77,7 @@ class JwksDict(TypedDict):
 class Auth0:
     def __init__(self, domain: str, api_audience: str, scopes: Dict[str, str]={},
             auto_error: bool=True, scope_auto_error: bool=True, email_auto_error: bool=False,
-            auth0user_model: Type[Auth0User]=Auth0User):
+            auth0user_model: Type[Auth0User]=Auth0User, options: Dict[str, Any] | None = None):
         self.domain = domain
         self.audience = api_audience
 
@@ -88,8 +88,6 @@ class Auth0:
         self.auth0_user_model = auth0user_model
 
         self.algorithms = ['RS256']
-        r = urllib.request.urlopen(f'https://{domain}/.well-known/jwks.json')
-        self.jwks: JwksDict = json.loads(r.read())
 
         authorization_url_qs = urllib.parse.urlencode({'audience': api_audience})
         authorization_url = f'https://{domain}/authorize?{authorization_url_qs}'
@@ -103,6 +101,8 @@ class Auth0:
             tokenUrl=f'https://{domain}/oauth/token',
             scopes=scopes)
         self.oidc_scheme = OpenIdConnect(openIdConnectUrl=f'https://{domain}/.well-known/openid-configuration')
+        self.options = options
+        self.jwks_client = PyJWKClient(f"https://{self.domain}/.well-known/jwks.json")
 
 
     async def get_user(self,
@@ -139,27 +139,20 @@ class Auth0:
                     logger.warning(msg)
                     return None
 
-            rsa_key = {}
-            for key in self.jwks['keys']:
-                if key['kid'] == unverified_header['kid']:
-                    rsa_key = {
-                        'kty': key['kty'],
-                        'kid': key['kid'],
-                        'use': key['use'],
-                        'n': key['n'],
-                        'e': key['e']
-                    }
-                    break
-            if rsa_key:
+            try:
+                signing_key = self.jwks_client.get_signing_key_from_jwt(token)
+                leeway = self.options.pop("leeway", 0) if self.options else 0
                 payload = jwt.decode(
                     token,
-                    rsa_key,
+                    signing_key.key,
                     algorithms=self.algorithms,
                     audience=self.audience,
-                    issuer=f'https://{self.domain}/'
+                    issuer=f"https://{self.domain}/",
+                    leeway=leeway,
+                    options=self.options,
                 )
-            else:
-                msg = 'Invalid kid header (wrong tenant or rotated public key)'
+            except jwt.PyJWKClientError as e:
+                msg = str(e)
                 if self.auto_error:
                     raise Auth0UnauthenticatedException(detail=msg)
                 else:
@@ -174,16 +167,16 @@ class Auth0:
                 logger.warning(msg)
                 return None
 
-        except jwt.JWTClaimsError:
-            msg = 'Invalid token claims (wrong issuer or audience)'
+        except (jwt.InvalidAudienceError, jwt.InvalidIssuerError):
+            msg = "Invalid token claims (wrong issuer or audience)"
             if self.auto_error:
                 raise Auth0UnauthenticatedException(detail=msg)
             else:
                 logger.warning(msg)
                 return None
 
-        except jwt.JWTError:
-            msg = 'Malformed token'
+        except jwt.PyJWTError as e:
+            msg = f"Malformed token: {e}"
             if self.auto_error:
                 raise Auth0UnauthenticatedException(detail=msg)
             else:


### PR DESCRIPTION
based on work started in https://github.com/dorinclisu/fastapi-auth0/pull/41

with cleanup
- require and verify needed claims that are produced by Auth0
- github-workflow set up
- obsolete classes
- and `Dict` instead of `dict` for py38 support

kept the Pydantic support for both v1 and v2